### PR TITLE
fix: implement ens integration for delegate address (#26)

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -1,4 +1,9 @@
+import os
+
+from dotenv import load_dotenv
 from pathlib import Path
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -118,6 +123,15 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# ShroomDKL settings enabling Blockchain data fixtures
+# ShroomDK settings enabling Blockchain data fixtures
 
-SHROOMDK_API_KEY = "7736f412-5e7b-4c43-8360-3e2231a24e69"
+SHROOMDK_KEY = os.environ.get("SHROOMDK_KEY")
+
+# Blockchain Data Providers
+
+PROVIDERS = {
+    "1": f"https://eth-mainnet.g.alchemy.com/v2/{os.environ.get('ETH_ALCHEMY_KEY')}",
+    "10": f"https://opt-mainnet.g.alchemy.com/v2/{os.environ.get('OPTIMISM_ALCHEMY_KEY')}",
+    "42161": f"https://arb-mainnet.g.alchemy.com/v2/{os.environ.get('ARBITRUM_ALCHEMY_KEY')}",
+    "137": f"https://polygon-mainnet.g.alchemy.com/v2/{os.environ.get('POLYGON_ALCHEMY_KEY')}",
+}

--- a/api/api/utils.py
+++ b/api/api/utils.py
@@ -1,0 +1,26 @@
+from ens import ENS
+from web3 import Web3
+
+from django.conf import settings
+
+mainnet_w3 = Web3(Web3.HTTPProvider(settings.PROVIDERS["1"]))
+ns = ENS.from_web3(mainnet_w3)
+
+
+class ENSCache:
+    def __init__(self):
+        self.use_cached_nulls = True
+
+    def address(self, name):
+        useattr = hasattr(self, name) and (
+            self.use_cached_nulls or getattr(self, name) is not None
+        )
+
+        if useattr:
+            return getattr(self, name)
+
+        address = ns.address(name)
+
+        setattr(self, name, address)
+
+        return address

--- a/api/button/models.py
+++ b/api/button/models.py
@@ -1,18 +1,46 @@
 import uuid
 
+from web3 import Web3
+
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
 from erc20.models import ERC20
+from api.utils import ENSCache
+
+ns = ENSCache()
 
 
 def validate_ethereum_address(value):
-    if not value.startswith("0x") or len(value) != 42:
+    if not Web3.is_address(value):
+        try:
+            ens_address = ns.address(value)
+
+            if ens_address is None:
+                raise ValidationError(
+                    _("%(value)s is not a valid Ethereum address or ENS name"),
+                    params={"value": value},
+                )
+
+            return ens_address
+        except ValueError:
+            raise ValidationError(
+                _("%(value)s is not a valid Ethereum address"),
+                params={"value": value},
+            )
+
+    try:
+        Web3.to_checksum_address(value)
+    except ValueError:
         raise ValidationError(
             _("%(value)s is not a valid Ethereum address"),
             params={"value": value},
         )
+
+    return value
 
 
 def validate_hex_color(value):
@@ -79,3 +107,11 @@ class Button(models.Model):
 
     class Meta:
         ordering = ["-created"]
+
+
+@receiver(post_save, sender=Button)
+def button_post_save(sender, instance, **kwargs):
+    if ".eth" in instance.ethereum_address:
+        instance.ethereum_address = validate_ethereum_address(instance.ethereum_address)
+
+        instance.save()

--- a/api/erc20/fixtures/erc20.py
+++ b/api/erc20/fixtures/erc20.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 from erc20.models import ERC20
 
-SHROOM = ShroomDK(settings.SHROOMDK_API_KEY)
+SHROOM = ShroomDK(settings.SHROOMDK_KEY)
 
 DELEGATION_TOPICS = [
     "'0x3134e8a2e6d97e929a7e54011ea5485d7d196dd5f0ba4d4ef95803e8e3fc257f'"

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,5 +3,8 @@ django-filter==23.1
 django-rest-framework==0.1.0
 markdown==3.4.3
 pip-chill==1.0.1
+python-dotenv==1.0.0
 pyyaml==6.0
 shroomdk==1.0.2
+uritemplate==4.1.1
+web3==6.0.0

--- a/frontend/src/pages/ButtonForm.tsx
+++ b/frontend/src/pages/ButtonForm.tsx
@@ -115,6 +115,11 @@ const ButtonForm = ({ isEdit }: { isEdit?: boolean }) => {
             })
             .then((res) => res.json())
             .then((data) => {
+                setErrors([])
+                setObject((object: any) => ({
+                    ...object,
+                    ethereum_address: data.ethereum_address,
+                }));
                 navigate(`/account/buttons/${data.id}/edit/`)
             })
             .catch((errors) => {


### PR DESCRIPTION
Implements the ability to provide an ENS address in place of the Delegate Ethereum Address. When provided, the backend will automatically validate the provided address, as well as format it back to the target address.

The value is not left in ENS form to prevent issues where a user changes their ENS and everything becomes out of sync.